### PR TITLE
Allow qmods from header-only libs

### DIFF
--- a/src/data/package/package_config.rs
+++ b/src/data/package/package_config.rs
@@ -33,6 +33,12 @@ pub struct AdditionalPackageData {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub local_path: Option<String>,
 
+    /// By default if empty, true
+    /// If false, this mod dependency will NOT be included in the generated mod.json
+    /// Technically just a dependency field
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub include_qmod: Option<bool>,
+
     /// Whether or not the package is header only
     #[serde(skip_serializing_if = "Option::is_none")]
     pub headers_only: Option<bool>,


### PR DESCRIPTION
Todo: Make this configurable
In the current state, this will likely force Chroma to be installed alongside mods like Qosmetics (and future TrickSaber) since both make use of Chroma API which provides the modlink.
Therefore we need a way to configure forcing a dependency not to be included, preferably outside of a `CLI` argument 