### PR TITLE
Add flag for NDK R25

### DIFF
--- a/src/data/package/shared_package_config.rs
+++ b/src/data/package/shared_package_config.rs
@@ -379,6 +379,7 @@ impl SharedPackageConfig {
             "\nset(ANDROID_PLATFORM 24)",
             "set(ANDROID_ABI arm64-v8a)",
             "set(ANDROID_STL c++_static)",
+            "set(ANDROID_USE_LEGACY_TOOLCHAIN_FILE OFF)",
             "\nset(CMAKE_TOOLCHAIN_FILE ${CMAKE_ANDROID_NDK}/build/cmake/android.toolchain.cmake)"
         ));
         result.push_str(concatln!(


### PR DESCRIPTION
This disable the legacy toolchain usage in Android CMake which has been reintroduced in NDK R25+