### PR TITLE
Add Publish subcommand, configurable authorization header

### DIFF
--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -1,7 +1,16 @@
+use clap::Args;
+
+#[derive(Args, Debug, Clone)]
+
+pub struct Publish {
+    /// the authorization header to use for publishing, if present
+    pub publish_auth: String,
+}
+
 use owo_colors::OwoColorize;
 
 use crate::data::package::SharedPackageConfig;
-pub fn execute_publish_operation() {
+pub fn execute_publish_operation(auth: &Publish) {
     let package = SharedPackageConfig::read();
     if package.config.info.url.is_none() {
         println!("Package without url can not publish!");
@@ -63,10 +72,11 @@ pub fn execute_publish_operation() {
 
     // TODO: Implement a check that gets the repo and checks if the shared folder and subfolder exists, if not it throws an error and won't let you publish
 
-    package.publish();
+    package.publish(&auth.publish_auth);
 
     println!(
         "Package {} v{} published!",
         package.config.info.id, package.config.info.version
     );
 }
+

--- a/src/data/config.rs
+++ b/src/data/config.rs
@@ -13,6 +13,8 @@ pub struct Config {
     pub timeout: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ndk_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub publish_auth: Option<String>,
 }
 
 impl Default for Config {
@@ -23,6 +25,7 @@ impl Default for Config {
             cache: Some(dirs::data_dir().unwrap().join("QPM-Rust").join("cache")),
             timeout: Some(5000),
             ndk_path: None,
+            publish_auth: None,
         }
     }
 }
@@ -56,6 +59,7 @@ impl Config {
                 cache: None,
                 timeout: None,
                 ndk_path: None,
+                publish_auth: None,
             }
         }
     }

--- a/src/data/package/shared_package_config.rs
+++ b/src/data/package/shared_package_config.rs
@@ -48,9 +48,9 @@ impl SharedPackageConfig {
         println!("Package {} Written!", self.config.info.id);
     }
 
-    pub fn publish(&self) {
+    pub fn publish(&self, auth: &str) {
         // ggez
-        qpackages::publish_package(self);
+        qpackages::publish_package(self, auth);
     }
 
     pub fn from_package(package: &PackageConfig) -> SharedPackageConfig {

--- a/src/data/qpackages.rs
+++ b/src/data/qpackages.rs
@@ -7,7 +7,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::{data::{package::SharedPackageConfig}, utils::network::get_agent};
 static API_URL: &str = "https://qpackages.com";
-static AUTH_HEADER: &str = "not that i can come up with";
 
 static VERSIONS_CACHE: Lazy<AtomicRefCell<HashMap<String, Vec<PackageVersion>>>> =
     Lazy::new(Default::default);
@@ -101,7 +100,7 @@ pub fn get_packages() -> Vec<String> {
         .expect("Into json failed")
 }
 
-pub fn publish_package(package: &SharedPackageConfig) {
+pub fn publish_package(package: &SharedPackageConfig, auth: &str) {
     let url = format!(
         "{}/{}/{}",
         API_URL, &package.config.info.id, &package.config.info.version
@@ -109,7 +108,7 @@ pub fn publish_package(package: &SharedPackageConfig) {
 
     get_agent()
         .post(&url)
-        .header("Authorization", AUTH_HEADER)
+        .header("Authorization", auth)
         .json(&package)
         .send()
         .expect("Request to qpackages.com failed");

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ enum MainCommand {
     /// List all properties that are currently supported by QPM
     List(commands::list::ListOperation),
     /// Publish package
-    Publish,
+    Publish(commands::publish::Publish),
     /// Restore and resolve all dependencies from the package
     Restore,
     /// Qmod control
@@ -57,7 +57,7 @@ fn main() {
         MainCommand::Dependency(d) => commands::dependency::execute_dependency_operation(d),
         MainCommand::Package(p) => commands::package::execute_package_operation(p),
         MainCommand::List(l) => commands::list::execute_list_operation(l),
-        MainCommand::Publish => commands::publish::execute_publish_operation(),
+        MainCommand::Publish(a) => commands::publish::execute_publish_operation(&a),
         MainCommand::Restore => commands::restore::execute_restore_operation(),
         MainCommand::Qmod(q) => commands::qmod::execute_qmod_operation(q),
         MainCommand::Install(i) => commands::install::execute_install_operation(i),


### PR DESCRIPTION
This will be necessary for the changes coming to the QPM backend soon. Also added it as a configuration option, but it cannot be saved via CLI at the moment. This may change, but if it does, it should change such that the local config NEVER holds it (likewise, the local config should NEVER hold the GH credentials)
