### PR TITLE
Add configuration subcommand for publish, update wording, keyring key

### DIFF
--- a/src/commands/config/mod.rs
+++ b/src/commands/config/mod.rs
@@ -5,6 +5,7 @@ mod ndkpath;
 mod symlink;
 mod timeout;
 mod token;
+mod publish;
 
 use owo_colors::OwoColorize;
 
@@ -36,6 +37,8 @@ pub enum ConfigOperation {
     Location,
     /// Get or set the ndk path used in generation of build files
     NDKPath(ndkpath::NDKPath),
+    /// Get or set the publish key used for publish
+    Publish(publish::Key),
 }
 
 pub fn execute_config_operation(operation: Config) {
@@ -63,7 +66,8 @@ pub fn execute_config_operation(operation: Config) {
         ),
         ConfigOperation::NDKPath(p) => {
             changed_any = ndkpath::execute_ndk_config_operation(&mut config, p)
-        }
+        },
+        ConfigOperation::Publish(k) => publish::execute_key_config_operation(k),
     }
 
     if !changed_any {

--- a/src/commands/config/publish.rs
+++ b/src/commands/config/publish.rs
@@ -1,0 +1,43 @@
+use clap::Args;
+use owo_colors::OwoColorize;
+
+use crate::data::config::get_publish_keyring;
+
+#[derive(Args, Debug, Clone)]
+pub struct Key {
+    pub key: Option<String>,
+    #[clap(long)]
+    pub delete: bool,
+}
+
+pub fn execute_key_config_operation(operation: Key) {
+    if operation.delete && get_publish_keyring().get_password().is_ok() {
+        get_publish_keyring()
+            .delete_password()
+            .expect("Removing publish key failed");
+        println!("Deleted publish key from config, it will no longer be used");
+        return;
+    } else if operation.delete {
+        println!("There was no publish key configured, did not delete it");
+        return;
+    }
+
+    if let Some(key) = operation.key {
+        // write key
+        get_publish_keyring().set_password(&key).expect("Failed to set publish key");
+        println!("Configured a publish key! This will now be used for future qpm publish calls");
+    } else {
+        // read token, possibly unused so prepend with _ to prevent warnings
+        if let Ok(_key) = get_publish_keyring().get_password() {
+            #[cfg(debug_assertions)]
+            println!("Configured publish key: {}", _key.bright_yellow());
+            #[cfg(not(debug_assertions))]
+            println!(
+                "In release builds you {} view the configured publish key!",
+                "cannot".bright_red()
+            );
+        } else {
+            println!("No publish key was configured, or getting the publish key failed!");
+        }
+    }
+}

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -1,10 +1,11 @@
 use clap::Args;
+use crate::data::config::get_publish_keyring;
 
 #[derive(Args, Debug, Clone)]
 
 pub struct Publish {
     /// the authorization header to use for publishing, if present
-    pub publish_auth: String,
+    pub publish_auth: Option<String>,
 }
 
 use owo_colors::OwoColorize;
@@ -72,7 +73,14 @@ pub fn execute_publish_operation(auth: &Publish) {
 
     // TODO: Implement a check that gets the repo and checks if the shared folder and subfolder exists, if not it throws an error and won't let you publish
 
-    package.publish(&auth.publish_auth);
+    if let Some(key) = &auth.publish_auth {
+        package.publish(&key);
+    } else {
+        // Empty strings are None, you shouldn't be able to publish with a None
+        let publish_key = get_publish_keyring();
+        package.publish(&publish_key.get_password().expect("Unable to get stored publish key!"));
+    }
+    
 
     println!(
         "Package {} v{} published!",

--- a/src/data/config.rs
+++ b/src/data/config.rs
@@ -12,9 +12,7 @@ pub struct Config {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timeout: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ndk_path: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub publish_auth: Option<String>,
+    pub ndk_path: Option<String>
 }
 
 impl Default for Config {
@@ -25,7 +23,6 @@ impl Default for Config {
             cache: Some(dirs::data_dir().unwrap().join("QPM-Rust").join("cache")),
             timeout: Some(5000),
             ndk_path: None,
-            publish_auth: None,
         }
     }
 }
@@ -38,7 +35,7 @@ impl Config {
 
         if let Ok(file) = std::fs::File::open(path) {
             // existed
-            serde_json::from_reader(file).expect("Deserializing package failed")
+            serde_json::from_reader(file).expect("Deserializing global config failed")
         } else {
             // didn't exist
             Config {
@@ -51,7 +48,7 @@ impl Config {
         let path = "qpm.settings.json";
         if let Ok(file) = std::fs::File::open(path) {
             // existed
-            serde_json::from_reader(file).expect("Deserializing package failed")
+            serde_json::from_reader(file).expect(&format!("Deserializing {} failed", path))
         } else {
             // didn't exist
             Config {
@@ -59,7 +56,6 @@ impl Config {
                 cache: None,
                 timeout: None,
                 ndk_path: None,
-                publish_auth: None,
             }
         }
     }
@@ -124,4 +120,8 @@ impl Config {
 #[inline]
 pub fn get_keyring() -> keyring::Entry {
     keyring::Entry::new("qpm", "github")
+}
+#[inline]
+pub fn get_publish_keyring() -> keyring::Entry {
+    keyring::Entry::new("qpm", "publish")
 }


### PR DESCRIPTION
`qpm-rust config publish` along with `--delete` allows you to use a cached publish key